### PR TITLE
Upload docker image to docker hub

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,3 +38,21 @@ pipeline:
     commands:
       - apk add --update --no-cache git make
       - make test
+
+  publish:
+    when:
+      event: push
+      status: success
+      branch: master
+    image: plugins/docker
+    pull: true
+    repo: samwang0723/genghis-khan
+    registry: ${DOCKER_REGISTRY}
+    tags:
+      - ${DRONE_COMMIT_SHA:0:8}
+    secrets:
+      - docker_username
+      - docker_password
+      - docker_registry
+    build_args:
+      - GIT_COMMIT_HASH=${DRONE_COMMIT_SHA}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ deps:
 
 .PHONY: build
 build:
-	docker-compose build
+	docker-compose build --force-rm
+	docker rmi `docker images -q -f dangling=true`
 
 .PHONY: up
 up:


### PR DESCRIPTION
## Why is this change necessary?

- Need docker image upload to docker registry in order to deploy

## How does it address the issue?

- Upload built docker image to docker hub private repository https://hub.docker.com/r/samwang0723/genghis-khan/

## What side effects does this change have?

- N/A
